### PR TITLE
Implement crap RFC 0002 ambient attachment protocol

### DIFF
--- a/docs/features/0002-crap-attach.md
+++ b/docs/features/0002-crap-attach.md
@@ -1,0 +1,93 @@
+---
+status: prototype
+date: 2026-06-11
+---
+
+# FDR 0002: Ambient CRAP Attachment (crap RFC 0002 prototype)
+
+just-us is the prototype implementation of the **CRAP attach protocol**
+(crap RFC 0002, `amarbel-llc/crap` →
+`docs/rfcs/0002-attach-protocol.md`): ambient detection of a
+crap-aware harness via a `CRAP=2` environment offer, a one-line JSON
+*hello* announcing the negotiated format, and recursive passthrough
+re-offers so a tree of producers lands in one nested ndjson-crap
+stream. This document records what the prototype implements, what it
+deliberately omits, and where it diverges; the RFC is normative.
+
+## What works
+
+```sh
+CRAP=2 just build | crap-present
+```
+
+- **Ambient activation** (`EventSink::from_ambient`): with
+  `--events-fd` / `JUST_EVENTS_FD` absent, a `CRAP=2` offer activates
+  the event sink. Channel: `CRAP_FD`, defaulting to stdout. Format:
+  first supported token of `CRAP_ACCEPT` (default `ndjson-crap/1`).
+  Every defect — unsupported version, no supported format, malformed
+  or dead descriptor — degrades silently to a noop sink (RFC §3); only
+  the explicit flag errors.
+- **Hello** (RFC §5): emitted lazily before the first record (silent
+  subcommands stay silent), carrying `version`/`ndjson`/`format`/
+  `producer`/`parent`. Never emitted under explicit `--events-fd`,
+  whose RFC 0002 contract pins `plan` first.
+- **Shared-channel discipline** (RFC §7): ambient tps draw from a
+  random base in `[2^40, 2^48)`; every record is serialized to a
+  buffer and written with one `write_all`; captured child output is
+  chunked at 1024 bytes per `output` record so serialized lines stay
+  under `PIPE_BUF`. A producer attached under `CRAP_PARENT` suppresses
+  `plan`; root recipes carry `parent` = `CRAP_PARENT` and depths are
+  offset by `CRAP_DEPTH`.
+- **Passthrough re-offer** (RFC §6.1): for every recipe child (linewise
+  and shebang/script paths), just exports `CRAP=2`,
+  `CRAP_FD=<dup of the channel>`, `CRAP_ACCEPT=ndjson-crap/1`,
+  `CRAP_PARENT=<recipe tp>`, `CRAP_DEPTH=<depth+1>`. A crap-aware
+  child (e.g. a nested `just`) attaches and nests; everything else
+  emits **garbage** — plain stdout/stderr — which the existing capture
+  path wraps as `output` records under the same node. Re-offering
+  happens under both ambient and explicit activation, so an
+  `--events-fd` consumer gets nested grandchildren too (their records
+  are new-to-RFC-0002 types, which its consumers must ignore).
+- **Withdraw for data consumption** (RFC §6): backtick / `shell()`
+  children have the offer removed (`EventSink::OFFER_VARS`) — their
+  stdout is evaluated as a value, and an attaching producer would leak
+  records into it.
+
+Verified end to end in this container: nested two-justfile runs under
+`CRAP=2` render via `crap-present` (plain fallback) and pass
+`:: validate` (16/16 records); the explicit `--events-fd` stream keeps
+its plan-first, monotonic-tp shape with the grandchild's hello and
+node records interleaved.
+
+## Deliberate omissions / divergences
+
+- **No out-of-band transport** (RFC §8): `inline` only; the hello
+  never carries `transport`. Reserved for a future format that needs
+  it.
+- **No `sid`** in the hello: random tp bases carry the
+  collision-avoidance load; add `sid` if consumer-side attribution
+  ever needs it.
+- **`CRAP_ACCEPT` re-offer is static** (`ndjson-crap/1`), not an echo
+  of the negotiated token — equivalent while only one format exists.
+- **Explicit `--events-fd` channels also re-offer** even though the
+  RFC only requires it of attached producers; the dup'd-descriptor
+  mechanism is identical. If a consumer of the explicit stream cannot
+  tolerate grandchild records, that consumer predates RFC 0002's
+  unknown-type tolerance and is already nonconforming.
+- **bats coverage is pending** (bats/nix unavailable in the authoring
+  container): the conformance rows in crap RFC 0002 map the planned
+  `zz-tests_bats/crap_attach.bats` (tag `crap_attach`); unit coverage
+  lives in `src/event.rs`.
+- The re-offer dup descriptor leaks (stays open until process exit) —
+  harmless single-digit fd cost, simplifies lifetime vs. spawned
+  children.
+
+## Implementation map
+
+| Concern | Where |
+| --- | --- |
+| offer parse, negotiate, hello, tp base, chunking | `src/event.rs` |
+| ambient fallback activation | `src/subcommand.rs` |
+| root `parent`/`depth` scoping | `src/justfile.rs` (`run`, `run_recipe`) |
+| re-offer at spawn, garbage capture chunking | `src/recipe.rs` |
+| withdraw for backticks / `shell()` | `src/evaluator.rs` (`run_command`) |

--- a/docs/features/0002-crap-attach.md
+++ b/docs/features/0002-crap-attach.md
@@ -1,9 +1,25 @@
 ---
-status: prototype
+status: prototype (transport superseded)
 date: 2026-06-11
 ---
 
 # FDR 0002: Ambient CRAP Attachment (crap RFC 0002 prototype)
+
+> **Status note (2026-06-12).** crap RFC 0002 was rewritten around a
+> client/birthed-server model: nodes are only ever clients of a
+> unix-socket sink server birthed by the tree's root (fork-and-become /
+> re-exec-self / external binary), which grants each connection a
+> disjoint deterministic id base and splices lines into one merged
+> stream. That dissolves this prototype's shared-fd machinery —
+> `CRAP_FD`, `CRAP_ACCEPT`, `CRAP_DEPTH`, the hello, the dup'd re-offer
+> descriptor, random tp bases, and the PIPE_BUF/chunking discipline are
+> all withdrawn from the spec. What this prototype validated survives:
+> ambient `CRAP=2` detection with silent degradation, `CRAP_PARENT`
+> lineage nesting, garbage capture, evaluation-child withdrawal,
+> explicit-flag precedence, and acceptance by `crap-present` /
+> `:: validate`. Reworking the implementation to `attach()`
+> connect-or-birth with granted bases is the tracked next step; until
+> then the code below implements the superseded first-draft transport.
 
 just-us is the prototype implementation of the **CRAP attach protocol**
 (crap RFC 0002, `amarbel-llc/crap` →

--- a/docs/features/0002-crap-attach.md
+++ b/docs/features/0002-crap-attach.md
@@ -1,109 +1,121 @@
 ---
-status: prototype (transport superseded)
-date: 2026-06-11
+status: prototype
+date: 2026-06-12
 ---
 
 # FDR 0002: Ambient CRAP Attachment (crap RFC 0002 prototype)
 
-> **Status note (2026-06-12).** crap RFC 0002 was rewritten around a
-> client/birthed-server model: nodes are only ever clients of a
-> unix-socket sink server birthed by the tree's root (fork-and-become /
-> re-exec-self / external binary), which grants each connection a
-> disjoint deterministic id base and splices lines into one merged
-> stream. That dissolves this prototype's shared-fd machinery —
-> `CRAP_FD`, `CRAP_ACCEPT`, `CRAP_DEPTH`, the hello, the dup'd re-offer
-> descriptor, random tp bases, and the PIPE_BUF/chunking discipline are
-> all withdrawn from the spec. What this prototype validated survives:
-> ambient `CRAP=2` detection with silent degradation, `CRAP_PARENT`
-> lineage nesting, garbage capture, evaluation-child withdrawal,
-> explicit-flag precedence, and acceptance by `crap-present` /
-> `:: validate`. Reworking the implementation to `attach()`
-> connect-or-birth with granted bases is the tracked next step; until
-> then the code below implements the superseded first-draft transport.
-
 just-us is the prototype implementation of the **CRAP attach protocol**
 (crap RFC 0002, `amarbel-llc/crap` →
-`docs/rfcs/0002-attach-protocol.md`): ambient detection of a
-crap-aware harness via a `CRAP=2` environment offer, a one-line JSON
-*hello* announcing the negotiated format, and recursive passthrough
-re-offers so a tree of producers lands in one nested ndjson-crap
-stream. This document records what the prototype implements, what it
-deliberately omits, and where it diverges; the RFC is normative.
+`docs/rfcs/0002-attach-protocol.md`), in its client/birthed-server
+form: ambient detection of a crap-aware harness via a `CRAP=2`
+environment offer, every node a *client* of a unix-socket sink server,
+roots *birthing* that server by re-exec'ing the just binary into an
+embedded serve loop, per-connection grants handing out disjoint
+deterministic id bases, and terminal roots electing one shared server
+per tty by atomic bind. This document records what the prototype
+implements, what it deliberately omits, and where it diverges; the RFC
+is normative.
+
+> An earlier revision of this prototype implemented the RFC's
+> superseded first draft (shared-fd passthrough: `CRAP_FD`, a hello
+> record, random tp bases, PIPE_BUF write discipline). That transport
+> is gone; the semantics it validated carried forward.
 
 ## What works
 
 ```sh
-CRAP=2 just build | crap-present
+CRAP=2 just build | crap-present   # root births a tree server
+CRAP=2 just build > run.ndjson     # ...whose stdout is the recorder
+CRAP=2 just build                  # tty: join-or-elect the terminal server
 ```
 
-- **Ambient activation** (`EventSink::from_ambient`): with
-  `--events-fd` / `JUST_EVENTS_FD` absent, a `CRAP=2` offer activates
-  the event sink. Channel: `CRAP_FD`, defaulting to stdout. Format:
-  first supported token of `CRAP_ACCEPT` (default `ndjson-crap/1`).
-  Every defect — unsupported version, no supported format, malformed
-  or dead descriptor — degrades silently to a noop sink (RFC §3); only
-  the explicit flag errors.
-- **Hello** (RFC §5): emitted lazily before the first record (silent
-  subcommands stay silent), carrying `version`/`ndjson`/`format`/
-  `producer`/`parent`. Never emitted under explicit `--events-fd`,
-  whose RFC 0002 contract pins `plan` first.
-- **Shared-channel discipline** (RFC §7): ambient tps draw from a
-  random base in `[2^40, 2^48)`; every record is serialized to a
-  buffer and written with one `write_all`; captured child output is
-  chunked at 1024 bytes per `output` record so serialized lines stay
-  under `PIPE_BUF`. A producer attached under `CRAP_PARENT` suppresses
-  `plan`; root recipes carry `parent` = `CRAP_PARENT` and depths are
-  offset by `CRAP_DEPTH`.
-- **Passthrough re-offer** (RFC §6.1): for every recipe child (linewise
-  and shebang/script paths), just exports `CRAP=2`,
-  `CRAP_FD=<dup of the channel>`, `CRAP_ACCEPT=ndjson-crap/1`,
-  `CRAP_PARENT=<recipe tp>`, `CRAP_DEPTH=<depth+1>`. A crap-aware
-  child (e.g. a nested `just`) attaches and nests; everything else
-  emits **garbage** — plain stdout/stderr — which the existing capture
-  path wraps as `output` records under the same node. Re-offering
-  happens under both ambient and explicit activation, so an
-  `--events-fd` consumer gets nested grandchildren too (their records
-  are new-to-RFC-0002 types, which its consumers must ignore).
-- **Withdraw for data consumption** (RFC §6): backtick / `shell()`
-  children have the offer removed (`EventSink::OFFER_VARS`) — their
-  stdout is evaluated as a value, and an attaching producer would leak
-  records into it.
+- **Attachment** (`crap_attach::attach`, RFC §3): with `--events-fd` /
+  `JUST_EVENTS_FD` absent and a `CRAP=2` offer present, just connects
+  to the inherited `CRAP_SINK` and reads the grant. Failures divide per
+  the RFC: *no server there* (missing socket, refused) ⇒ re-root;
+  *a server said no* (deny grant, EOF-before-grant, malformed grant,
+  foreign format) ⇒ unattached, never a surprise server. Attachment is
+  gated to recipe-running subcommands (`run`/`choose`/command/evaluate)
+  so `--list` and friends never touch a sink, and happens at startup —
+  before any recipe — satisfying connect-before-spawn.
+- **Root election** (RFC §3 step 3): stdout-is-a-tty ⇒ join-or-elect
+  the tty-keyed terminal server (`tty-<maj>.<min>.sock`, bind = win,
+  `EADDRINUSE` = lose and connect; stale paths reclaimed under a
+  sidecar `flock`). Otherwise ⇒ birth a private tree server whose
+  merged output is the inherited stdout. A re-rooted node clears any
+  inherited `CRAP_PARENT` (it named a node in the dead tree's id
+  namespace).
+- **The embedded server** (`crap_serve`, RFC §6): this same binary
+  re-exec'd with an internal marker env var (the RFC's "re-exec self"
+  embodiment — Go-style, no fork hazards, no external dependency). It
+  receives the pre-bound listener (no readiness race) and splices
+  complete lines from all connections to its output in arrival order —
+  never parsing or reordering records. Grants are
+  `{"type":"crap","version":2,"base":k·2^32,"format":"ndjson-crap/1"}`
+  in accept order, so the first client (normally the root) emits plain
+  `tp: 1, 2, 3…` and a single-producer stream is byte-identical to an
+  `--events-fd` stream. Tree servers exit on lease EOF (a pipe whose
+  write end the spawner holds for life — survives SIGKILL) with a 2s
+  drain grace; terminal servers are refcounted (1s linger after the
+  last disconnect, 10s first-client deadline) and ignore
+  SIGINT/SIGHUP so ^C and pty teardown still reach the
+  drain/flush/unlink path. Terminal servers pipe their output into
+  `crap-present` when it is on PATH (presentation), falling back to a
+  raw splice.
+- **Scoping children** (RFC §5): each recipe child gets
+  `CRAP`/`CRAP_SINK`/`CRAP_PARENT=<recipe tp>` in its environment — a
+  crap-aware child connects to the sink *itself* (its records never
+  pass through just) and nests; everything else emits **garbage**,
+  which the capture path wraps as `output` records chunked at 8 KiB
+  (the RFC's 64 KiB line-hygiene bound with worst-case JSON-escaping
+  headroom). Backtick / `shell()` children get the offer withdrawn
+  (`EventSink::OFFER_VARS`) — evaluation is not execution.
+- **Explicit `--events-fd`** is untouched: direct descriptor writes,
+  plan-first, monotonic tps, error on invalid fd, no scoping env for
+  children (an fd is not a connectable sink address).
 
-Verified end to end in this container: nested two-justfile runs under
-`CRAP=2` render via `crap-present` (plain fallback) and pass
-`:: validate` (16/16 records); the explicit `--events-fd` stream keeps
-its plan-first, monotonic-tp shape with the grandchild's hello and
-node records interleaved.
+Verified end to end in this container: a nested two-justfile run under
+`CRAP=2` produces one merged stream (root tps `1..n`, inner just at
+base 2^32 parented under the outer recipe's node, nested plan
+suppressed) that passes `:: validate` (14/14) and renders via
+`crap-present`; a dead `CRAP_SINK` re-roots into a complete standalone
+stream; two parallel roofless justs on one pty converge on a single
+terminal server as sibling top-level trees with disjoint bases; the
+terminal server feeds `crap-present` when present; servers exit and
+unlink their sockets after their tree/clients end.
 
 ## Deliberate omissions / divergences
 
-- **No out-of-band transport** (RFC §8): `inline` only; the hello
-  never carries `transport`. Reserved for a future format that needs
-  it.
-- **No `sid`** in the hello: random tp bases carry the
-  collision-avoidance load; add `sid` if consumer-side attribution
-  ever needs it.
-- **`CRAP_ACCEPT` re-offer is static** (`ndjson-crap/1`), not an echo
-  of the negotiated token — equivalent while only one format exists.
-- **Explicit `--events-fd` channels also re-offer** even though the
-  RFC only requires it of attached producers; the dup'd-descriptor
-  mechanism is identical. If a consumer of the explicit stream cannot
-  tolerate grandchild records, that consumer predates RFC 0002's
-  unknown-type tolerance and is already nonconforming.
+- **No scope check at accept** (RFC §6.1 SHOULD): the server grants
+  any same-user peer; peer-credential ancestry / ctty verification is
+  pending. Until then, deny grants are emitted only for protocol
+  errors, not trespass.
+- **fork-and-become** (RFC §6.2's first embodiment) is not used —
+  re-exec-self is simpler and immune to fork-in-threaded-process
+  hazards. The serve loop is structured to permit a fork-safe
+  embedding later (poll loop, no threads).
+- **Terminal raw-splice fallback** prints ndjson at a human when
+  `crap-present` is absent — RFC-permitted last resort.
+- The lease write end and the server child handle are deliberately
+  leaked/unwaited: the lease must live exactly as long as the process,
+  and the server outlives us by design (init reaps it).
 - **bats coverage is pending** (bats/nix unavailable in the authoring
-  container): the conformance rows in crap RFC 0002 map the planned
+  container): the RFC's conformance table is the spec for
   `zz-tests_bats/crap_attach.bats` (tag `crap_attach`); unit coverage
-  lives in `src/event.rs`.
-- The re-offer dup descriptor leaks (stays open until process exit) —
-  harmless single-digit fd cost, simplifies lifetime vs. spawned
-  children.
+  lives in `src/event.rs`, `src/crap_attach.rs`, and
+  `src/crap_serve.rs` (including a real-socket grant/splice/lease
+  test).
 
 ## Implementation map
 
 | Concern | Where |
 | --- | --- |
-| offer parse, negotiate, hello, tp base, chunking | `src/event.rs` |
-| ambient fallback activation | `src/subcommand.rs` |
-| root `parent`/`depth` scoping | `src/justfile.rs` (`run`, `run_recipe`) |
-| re-offer at spawn, garbage capture chunking | `src/recipe.rs` |
+| attach procedure, grant exchange, root election, birth | `src/crap_attach.rs` |
+| serve loop: grants, splice, lease/refcount lifetimes, presenter | `src/crap_serve.rs` |
+| serve-mode entry hook (before arg parsing) | `src/run.rs` |
+| `EventSink` ambient construction, granted-base tps, child scoping env, plan suppression | `src/event.rs` |
+| ambient gating to recipe-running subcommands | `src/subcommand.rs` |
+| root `parent` scoping | `src/justfile.rs` (`run`) |
+| scoping env at spawn, garbage capture chunking | `src/recipe.rs` |
 | withdraw for backticks / `shell()` | `src/evaluator.rs` (`run_command`) |

--- a/src/crap_attach.rs
+++ b/src/crap_attach.rs
@@ -1,0 +1,364 @@
+//! Client side of the CRAP attach protocol (crap RFC 0002): detect a
+//! `CRAP=2` offer, connect to the sink server named by `CRAP_SINK`, or
+//! — as a root-capable node — birth one (a re-exec of this binary into
+//! `crap_serve`) and connect to it. Terminal roots rendezvous on a
+//! tty-keyed socket path; the kernel's bind atomicity is the leader
+//! election.
+
+use {
+  super::*,
+  std::{
+    io::Read,
+    os::fd::AsRawFd,
+    os::unix::net::{UnixListener, UnixStream},
+    time::Duration,
+  },
+};
+
+/// A successful attachment: a connected sink, the id base granted to
+/// this connection, and the metadata children need.
+pub(crate) struct Attachment {
+  /// Granted node-id base; ids are `base + n`, `n` from 1.
+  pub(crate) base: usize,
+  /// `CRAP_PARENT` from the offer: harness node our roots nest under.
+  pub(crate) parent: Option<usize>,
+  /// Sink address, re-exported to children alongside their
+  /// `CRAP_PARENT`.
+  pub(crate) sink_path: String,
+  /// The connection itself; records are written here.
+  pub(crate) stream: UnixStream,
+}
+
+enum AttachError {
+  /// A live server answered and said no (deny grant, EOF before
+  /// grant, malformed grant, unsupported format): degrade to dumb
+  /// output. MUST NOT birth a surprise server.
+  Denied,
+  /// Nothing answered (missing socket, refused connection): per RFC
+  /// 0002 §3, proceed as if `CRAP_SINK` were absent and re-root.
+  NoServer,
+}
+
+/// CRAP major version this client implements.
+const CRAP_VERSION: &str = "2";
+
+const FORMAT: &str = "ndjson-crap/1";
+
+/// Perform the RFC 0002 §3 attachment procedure. `None` means
+/// unattached: behave as if the protocol did not exist. Every failure
+/// mode degrades silently.
+pub(crate) fn attach() -> Option<Attachment> {
+  let version = env::var("CRAP").ok()?;
+  if version.trim() != CRAP_VERSION {
+    return None;
+  }
+  let parent = env::var("CRAP_PARENT")
+    .ok()
+    .and_then(|value| value.trim().parse().ok());
+  if let Ok(path) = env::var("CRAP_SINK") {
+    match connect(&path) {
+      Ok((stream, base)) => {
+        return Some(Attachment {
+          base,
+          parent,
+          sink_path: path,
+          stream,
+        });
+      }
+      Err(AttachError::Denied) => return None,
+      Err(AttachError::NoServer) => {}
+    }
+  }
+  // Root-capable: no sink above (or a dead one). RFC 0002 §3 step 3.
+  // Any inherited CRAP_PARENT named a node in the dead tree's id
+  // namespace; in the fresh tree it would dangle (and wrongly mark us
+  // nested), so roots start unparented.
+  let dir = runtime_dir()?;
+  // SAFETY: `isatty` has no preconditions.
+  if unsafe { libc::isatty(libc::STDOUT_FILENO) } == 1 {
+    terminal_attach(&dir)
+  } else {
+    tree_attach(&dir)
+  }
+}
+
+/// Birth a private tree server (RFC 0002 §6.2) whose merged output is
+/// our inherited stdout, then connect to it.
+fn tree_attach(dir: &Path) -> Option<Attachment> {
+  let path = dir.join(format!("tree-{}.sock", process::id()));
+  let _ = fs::remove_file(&path);
+  let listener = UnixListener::bind(&path).ok()?;
+  let path = path.to_str()?.to_owned();
+  birth(listener, &path, ServeMode::Tree).ok()?;
+  let (stream, base) = connect(&path).ok()?;
+  Some(Attachment {
+    base,
+    parent: None,
+    sink_path: path,
+    stream,
+  })
+}
+
+/// Join or elect the terminal's shared server (RFC 0002 §6.3): each
+/// tty has zero or one server, never more. The socket path is derived
+/// from the controlling terminal's device number; binding it IS the
+/// election, and losers connect as clients.
+fn terminal_attach(dir: &Path) -> Option<Attachment> {
+  let path = dir.join(tty_socket_name(stdout_rdev()?));
+  let path = path.to_str()?.to_owned();
+  for _ in 0..4 {
+    match connect(&path) {
+      Ok((stream, base)) => {
+        return Some(Attachment {
+          base,
+          parent: None,
+          sink_path: path,
+          stream,
+        });
+      }
+      Err(AttachError::Denied) => return None,
+      Err(AttachError::NoServer) => {}
+    }
+    match UnixListener::bind(&path) {
+      Ok(listener) => {
+        birth(listener, &path, ServeMode::Terminal).ok()?;
+        // Loop back to connect to the server we just elected.
+      }
+      Err(error) if error.kind() == io::ErrorKind::AddrInUse => {
+        // Either we lost the election race (a live server bound it
+        // between our connect and bind — loop back and connect), or
+        // the path is stale debris from a crashed server. Disambiguate
+        // and reclaim under a sidecar lock so two reclaimers cannot
+        // both bind (RFC 0002 §6.3 step 3).
+        if !reclaim_stale(&path) {
+          continue;
+        }
+        let Ok(listener) = UnixListener::bind(&path) else {
+          continue;
+        };
+        birth(listener, &path, ServeMode::Terminal).ok()?;
+      }
+      Err(_) => return None,
+    }
+  }
+  None
+}
+
+/// With `<path>.lock` held, re-verify the socket is dead and unlink
+/// it. Returns true when the caller should try binding.
+fn reclaim_stale(path: &str) -> bool {
+  let Ok(lock) = File::create(format!("{path}.lock")) else {
+    return false;
+  };
+  // SAFETY: flock on a valid descriptor; LOCK_EX blocks until held.
+  if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX) } != 0 {
+    return false;
+  }
+  // Lock held (released on drop/close). Someone may have reclaimed
+  // and rebound while we waited; a live server now means we should
+  // just connect (return false → caller loops back to connect).
+  if UnixStream::connect(path).is_ok() {
+    return false;
+  }
+  let _ = fs::remove_file(path);
+  true
+}
+
+/// Connect and perform the grant exchange (RFC 0002 §4): the server
+/// answers each accept with exactly one JSON line, either a base
+/// grant or a denial.
+fn connect(path: &str) -> Result<(UnixStream, usize), AttachError> {
+  let stream = UnixStream::connect(path).map_err(|error| match error.kind() {
+    io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused => AttachError::NoServer,
+    _ => AttachError::Denied,
+  })?;
+  let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+  let mut line = Vec::new();
+  let mut byte = [0u8; 1];
+  loop {
+    match (&stream).read(&mut byte) {
+      Ok(1) if byte[0] == b'\n' => break,
+      Ok(1) => {
+        if line.len() >= 4096 {
+          return Err(AttachError::Denied);
+        }
+        line.push(byte[0]);
+      }
+      // EOF before a grant is an answered denial, not absence.
+      _ => return Err(AttachError::Denied),
+    }
+  }
+  let base = parse_grant(&line)?;
+  let _ = stream.set_read_timeout(None);
+  Ok((stream, base))
+}
+
+/// Parse a grant line into the granted base. Anything other than a
+/// well-formed CRAP-2 base grant for a format we can emit — including
+/// an explicit `deny` — is a denial.
+fn parse_grant(line: &[u8]) -> Result<usize, AttachError> {
+  let value: serde_json::Value = serde_json::from_slice(line).map_err(|_| AttachError::Denied)?;
+  if value.get("deny").is_some() {
+    return Err(AttachError::Denied);
+  }
+  if value.get("version").and_then(serde_json::Value::as_u64) != Some(2)
+    || value.get("format").and_then(serde_json::Value::as_str) != Some(FORMAT)
+  {
+    return Err(AttachError::Denied);
+  }
+  value
+    .get("base")
+    .and_then(serde_json::Value::as_u64)
+    .and_then(|base| usize::try_from(base).ok())
+    .ok_or(AttachError::Denied)
+}
+
+/// Spawn this binary re-exec'd into the serve loop (RFC 0002 §6.2,
+/// "re-exec self"), handing it the pre-bound listener — so there is no
+/// readiness race — plus, for tree servers, the read end of the lease
+/// pipe whose write end we hold for the rest of our life.
+fn birth(listener: UnixListener, path: &str, mode: ServeMode) -> io::Result<()> {
+  let exe = env::current_exe()?;
+  clear_cloexec(listener.as_raw_fd())?;
+  let mut command = Command::new(exe);
+  command
+    .env(crap_serve::MARKER_VAR, "1")
+    .env(crap_serve::LISTEN_FD_VAR, listener.as_raw_fd().to_string())
+    .env(crap_serve::PATH_VAR, path)
+    .env(crap_serve::MODE_VAR, mode.as_str())
+    .env_remove("CRAP_SINK")
+    .stdin(Stdio::null());
+  let lease = if let ServeMode::Tree = mode {
+    let mut fds = [0i32; 2];
+    // SAFETY: plain pipe(2); fds are written on success only.
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+      return Err(io::Error::last_os_error());
+    }
+    // The write end must be ours alone — if the server (or any other
+    // exec'd child) inherited a copy, the lease could never EOF and
+    // the server would outlive the tree. Mark it close-on-exec BEFORE
+    // any spawn; we keep it open for our whole life (deliberately
+    // leaked), and its closure at our death is the server's signal to
+    // drain and exit.
+    // SAFETY: fcntl on a descriptor we just created.
+    if unsafe { libc::fcntl(fds[1], libc::F_SETFD, libc::FD_CLOEXEC) } == -1 {
+      let error = io::Error::last_os_error();
+      // SAFETY: closing both ends we own.
+      unsafe {
+        libc::close(fds[0]);
+        libc::close(fds[1]);
+      }
+      return Err(error);
+    }
+    command.env(crap_serve::LEASE_FD_VAR, fds[0].to_string());
+    Some(fds)
+  } else {
+    None
+  };
+  let spawned = command.spawn();
+  if let Some([read, write]) = lease {
+    // SAFETY: we own both ends; the child inherited its own copy of
+    // the read end across spawn.
+    unsafe {
+      libc::close(read);
+      if spawned.is_err() {
+        libc::close(write);
+      }
+    }
+  }
+  spawned.map(|_child| ())
+  // The Child handle is dropped without wait: the server outlives us
+  // by design (it drains after our exit) and is reparented and reaped
+  // by init, so no zombie accrues.
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum ServeMode {
+  /// Shared per terminal; exits when its last client disconnects.
+  Terminal,
+  /// Private to one tree; exits on lease EOF.
+  Tree,
+}
+
+impl ServeMode {
+  pub(crate) fn as_str(self) -> &'static str {
+    match self {
+      Self::Terminal => "terminal",
+      Self::Tree => "tree",
+    }
+  }
+}
+
+fn clear_cloexec(fd: i32) -> io::Result<()> {
+  // SAFETY: fcntl on a valid owned descriptor.
+  if unsafe { libc::fcntl(fd, libc::F_SETFD, 0) } == -1 {
+    return Err(io::Error::last_os_error());
+  }
+  Ok(())
+}
+
+/// `$XDG_RUNTIME_DIR/crap/` (0700), falling back to `$TMPDIR`/`/tmp`.
+fn runtime_dir() -> Option<PathBuf> {
+  let base = env::var_os("XDG_RUNTIME_DIR")
+    .map(PathBuf::from)
+    .or_else(|| env::var_os("TMPDIR").map(PathBuf::from))
+    .unwrap_or_else(|| PathBuf::from("/tmp"));
+  let dir = base.join("crap");
+  let mut builder = fs::DirBuilder::new();
+  std::os::unix::fs::DirBuilderExt::mode(&mut builder, 0o700);
+  match builder.create(&dir) {
+    Ok(()) => Some(dir),
+    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Some(dir),
+    Err(_) => None,
+  }
+}
+
+/// Device number of the controlling terminal on stdout.
+fn stdout_rdev() -> Option<u64> {
+  // SAFETY: fstat on stdout with a zeroed out-param.
+  let mut stat: libc::stat = unsafe { mem::zeroed() };
+  // SAFETY: stdout is always a valid descriptor number and the
+  // out-param is live for the call.
+  if unsafe { libc::fstat(libc::STDOUT_FILENO, &raw mut stat) } != 0 {
+    return None;
+  }
+  Some(stat.st_rdev)
+}
+
+/// RFC 0002 §6.3: the tty-keyed rendezvous name, derived from the
+/// terminal's device number so every roofless root on one terminal
+/// computes the same path.
+fn tty_socket_name(rdev: u64) -> String {
+  let (major, minor) = (libc::major(rdev), libc::minor(rdev));
+  format!("tty-{major}.{minor}.sock")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_grant_accepts_base_grant() {
+    let line = br#"{"type":"crap","version":2,"base":4294967296,"format":"ndjson-crap/1"}"#;
+    assert!(matches!(parse_grant(line), Ok(0x1_0000_0000)));
+  }
+
+  #[test]
+  fn parse_grant_denies_deny_and_malformed() {
+    for line in [
+      br#"{"type":"crap","version":2,"deny":"scope"}"#.as_slice(),
+      br#"{"type":"crap","version":3,"base":0,"format":"ndjson-crap/1"}"#.as_slice(),
+      br#"{"type":"crap","version":2,"base":0,"format":"crap-pack/1"}"#.as_slice(),
+      br#"{"type":"crap","version":2,"format":"ndjson-crap/1"}"#.as_slice(),
+      b"not json".as_slice(),
+    ] {
+      assert!(matches!(parse_grant(line), Err(AttachError::Denied)));
+    }
+  }
+
+  #[test]
+  fn tty_socket_name_is_deterministic() {
+    assert_eq!(tty_socket_name(0x8803), tty_socket_name(0x8803));
+    assert_ne!(tty_socket_name(0x8803), tty_socket_name(0x8804));
+  }
+}

--- a/src/crap_serve.rs
+++ b/src/crap_serve.rs
@@ -1,0 +1,332 @@
+//! The CRAP sink server (crap RFC 0002 §6): birthed by a root via
+//! re-exec of this binary, it owns one unix socket, answers each
+//! accept with a grant carrying a disjoint id base, and splices
+//! complete record lines from all connections to its merged output in
+//! arrival order. It never parses, reorders, or rewrites records.
+//! Tree servers exit on lease EOF (the spawner died); terminal servers
+//! exit when their last client disconnects.
+
+use {
+  super::*,
+  std::{
+    io::Read,
+    os::fd::FromRawFd,
+    os::unix::net::{UnixListener, UnixStream},
+    time::Duration,
+  },
+};
+
+pub(crate) const MARKER_VAR: &str = "JUST_US_INTERNAL_CRAP_SERVE";
+pub(crate) const LISTEN_FD_VAR: &str = "JUST_US_INTERNAL_CRAP_SERVE_LISTEN_FD";
+pub(crate) const LEASE_FD_VAR: &str = "JUST_US_INTERNAL_CRAP_SERVE_LEASE_FD";
+pub(crate) const PATH_VAR: &str = "JUST_US_INTERNAL_CRAP_SERVE_PATH";
+pub(crate) const MODE_VAR: &str = "JUST_US_INTERNAL_CRAP_SERVE_MODE";
+
+/// Per-connection line buffers are bounded; a line that exceeds the
+/// cap without a newline drops its connection (RFC 0002 §6.1 requires
+/// support to at least 64 KiB; producers SHOULD chunk below that).
+const MAX_LINE: usize = 1 << 20;
+
+/// How long a terminal server lingers after its last client
+/// disconnects, so back-to-back commands reuse it.
+const TERMINAL_LINGER: Duration = Duration::from_millis(1000);
+
+/// How long an elected terminal server waits for its first client.
+const TERMINAL_FIRST_CLIENT: Duration = Duration::from_secs(10);
+
+/// How long a tree server drains open connections after lease EOF.
+const DRAIN_GRACE: Duration = Duration::from_secs(2);
+
+/// Disjoint base per accepted connection: the k-th connection gets
+/// k·2^32, so the first client (normally the root itself) emits plain
+/// 1, 2, 3, … (RFC 0002 §4).
+const BASE_STRIDE: u64 = 1 << 32;
+
+pub(crate) fn enabled() -> bool {
+  env::var_os(MARKER_VAR).is_some()
+}
+
+struct Connection {
+  buf: Vec<u8>,
+  stream: UnixStream,
+}
+
+/// Run the serve loop on the inherited descriptors. Returns the
+/// process exit code; the caller (`run()`) exits with it immediately —
+/// no Config parsing, no justfile loading.
+pub(crate) fn serve() -> i32 {
+  // A terminal server shares the foreground process group and
+  // session; ignore SIGINT (a ^C aimed at the tree) and SIGHUP (pty
+  // teardown) so we always reach the drain/flush/unlink path — after
+  // either signal the clients die, their disconnects empty the
+  // refcount, and we exit cleanly. SIGTERM stays deliverable.
+  // SAFETY: SIG_IGN installation has no preconditions.
+  unsafe {
+    libc::signal(libc::SIGINT, libc::SIG_IGN);
+    libc::signal(libc::SIGHUP, libc::SIG_IGN);
+  }
+  let Some(listener) = fd_from_env(LISTEN_FD_VAR) else {
+    return EXIT_FAILURE;
+  };
+  // SAFETY: the fd numbers arrive from our spawner, which cleared
+  // close-on-exec on descriptors it owns; we take sole ownership.
+  let listener = unsafe { UnixListener::from_raw_fd(listener) };
+  // SAFETY: same provenance as the listener — an inherited descriptor
+  // our spawner created for us; we take sole ownership.
+  let lease = fd_from_env(LEASE_FD_VAR).map(|fd| unsafe { File::from_raw_fd(fd) });
+  let path = env::var(PATH_VAR).ok();
+  let terminal = env::var(MODE_VAR).as_deref() == Ok("terminal");
+  let output = open_output(terminal);
+  let code = run_server(&listener, lease, output, terminal);
+  if let Some(path) = path {
+    let _ = fs::remove_file(path);
+  }
+  code
+}
+
+fn fd_from_env(var: &str) -> Option<i32> {
+  env::var(var).ok()?.trim().parse().ok()
+}
+
+/// The merged stream's destination. Tree servers splice to inherited
+/// stdout (a pipe or file the root's caller arranged). Terminal
+/// servers land on a human's tty, so they SHOULD present: pipe into
+/// `crap-present` when available, falling back to a raw splice (RFC
+/// 0002 §6.3 permits it as a last resort).
+fn open_output(terminal: bool) -> Box<dyn Write> {
+  if terminal {
+    if let Ok(child) = Command::new("crap-present").stdin(Stdio::piped()).spawn() {
+      if let Some(stdin) = child.stdin {
+        return Box::new(stdin);
+      }
+    }
+  }
+  Box::new(io::stdout())
+}
+
+/// The loop proper, factored over arbitrary output for testability.
+fn run_server(
+  listener: &UnixListener,
+  lease: Option<File>,
+  mut output: Box<dyn Write>,
+  terminal: bool,
+) -> i32 {
+  use std::os::fd::AsRawFd;
+  if listener.set_nonblocking(true).is_err() {
+    return EXIT_FAILURE;
+  }
+  let mut connections: Vec<Connection> = Vec::new();
+  let mut granted: u64 = 0;
+  let mut lease_eof = lease.is_none();
+  let mut accepting = true;
+  let mut deadline: Option<Instant> = terminal.then(|| Instant::now() + TERMINAL_FIRST_CLIENT);
+  loop {
+    let mut fds: Vec<libc::pollfd> = Vec::with_capacity(connections.len() + 2);
+    let listener_index = accepting.then(|| {
+      fds.push(libc::pollfd {
+        fd: listener.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+      });
+      fds.len() - 1
+    });
+    let lease_index = lease.as_ref().filter(|_| !lease_eof).map(|lease| {
+      fds.push(libc::pollfd {
+        fd: lease.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+      });
+      fds.len() - 1
+    });
+    let connection_offset = fds.len();
+    for connection in &connections {
+      fds.push(libc::pollfd {
+        fd: connection.stream.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+      });
+    }
+    // SAFETY: fds points at a live, correctly-sized pollfd slice.
+    let rc = unsafe {
+      libc::poll(
+        fds.as_mut_ptr(),
+        fds.len() as libc::nfds_t,
+        250, // wake regularly to evaluate deadlines
+      )
+    };
+    if rc < 0 && io::Error::last_os_error().kind() != io::ErrorKind::Interrupted {
+      return EXIT_FAILURE;
+    }
+    if let Some(index) = listener_index {
+      if fds[index].revents != 0 {
+        while let Ok((stream, _)) = listener.accept() {
+          let grant = format!(
+            "{{\"type\":\"crap\",\"version\":2,\"base\":{},\"format\":\"ndjson-crap/1\"}}\n",
+            granted * BASE_STRIDE,
+          );
+          granted += 1;
+          deadline = None;
+          let mut stream = stream;
+          if stream.write_all(grant.as_bytes()).is_ok() && stream.set_nonblocking(true).is_ok() {
+            connections.push(Connection {
+              buf: Vec::new(),
+              stream,
+            });
+          }
+        }
+      }
+    }
+    if let Some(index) = lease_index {
+      if fds[index].revents != 0 {
+        let mut scratch = [0u8; 64];
+        if let Some(lease) = &lease {
+          if matches!((&*lease).read(&mut scratch), Ok(0) | Err(_)) {
+            lease_eof = true;
+            accepting = false;
+            deadline = Some(Instant::now() + DRAIN_GRACE);
+          }
+        }
+      }
+    }
+    let mut index = 0;
+    while index < connections.len() {
+      let ready = fds
+        .get(connection_offset + index)
+        .is_some_and(|fd| fd.revents != 0);
+      if ready && !pump(&mut connections[index], &mut output) {
+        connections.swap_remove(index);
+        if terminal && connections.is_empty() {
+          deadline = Some(Instant::now() + TERMINAL_LINGER);
+        }
+      } else {
+        index += 1;
+      }
+    }
+    let _ = output.flush();
+    if lease_eof && !terminal {
+      let drained = connections.is_empty() || deadline.is_some_and(|d| Instant::now() >= d);
+      if drained {
+        return EXIT_SUCCESS;
+      }
+    }
+    if terminal && connections.is_empty() {
+      if let Some(deadline) = deadline {
+        if Instant::now() >= deadline {
+          return EXIT_SUCCESS;
+        }
+      }
+    }
+  }
+}
+
+/// Drain readable bytes from one connection, splicing every complete
+/// line to the output atomically (we are the only writer, so a single
+/// `write_all` per line suffices). Returns false when the connection
+/// is finished and should be dropped.
+fn pump(connection: &mut Connection, output: &mut Box<dyn Write>) -> bool {
+  let mut chunk = [0u8; 4096];
+  loop {
+    match (&connection.stream).read(&mut chunk) {
+      Ok(0) => {
+        // Tolerate a final unterminated fragment: better a newline
+        // appended than records silently dropped.
+        if !connection.buf.is_empty() {
+          let _ = output.write_all(&connection.buf);
+          let _ = output.write_all(b"\n");
+        }
+        return false;
+      }
+      Ok(n) => {
+        connection.buf.extend_from_slice(&chunk[..n]);
+        while let Some(end) = connection.buf.iter().position(|&byte| byte == b'\n') {
+          let _ = output.write_all(&connection.buf[..=end]);
+          connection.buf.drain(..=end);
+        }
+        if connection.buf.len() > MAX_LINE {
+          return false;
+        }
+      }
+      Err(error) if error.kind() == io::ErrorKind::WouldBlock => return true,
+      Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+      Err(_) => return false,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use {super::*, std::os::unix::net::UnixStream};
+
+  struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+  impl Write for SharedBuf {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+      self.0.lock().unwrap().extend_from_slice(data);
+      Ok(data.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+      Ok(())
+    }
+  }
+
+  /// End-to-end over a real socket: two clients get disjoint bases in
+  /// accept order, their lines splice whole, and lease EOF ends the
+  /// server.
+  #[test]
+  fn grants_bases_and_splices_lines() {
+    let dir = testing::tempdir();
+    let path = dir.path().join("sink.sock");
+    let listener = UnixListener::bind(&path).unwrap();
+    let mut lease_fds = [0i32; 2];
+    // SAFETY: plain pipe(2).
+    assert_eq!(unsafe { libc::pipe(lease_fds.as_mut_ptr()) }, 0);
+    // SAFETY: we own both fresh descriptors.
+    let lease_read = unsafe { File::from_raw_fd(lease_fds[0]) };
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let output = Box::new(SharedBuf(Arc::clone(&buf)));
+    let server = thread::spawn(move || run_server(&listener, Some(lease_read), output, false));
+
+    let read_grant = |stream: &UnixStream| -> serde_json::Value {
+      let mut line = Vec::new();
+      let mut byte = [0u8; 1];
+      while (&*stream).read(&mut byte).unwrap() == 1 && byte[0] != b'\n' {
+        line.push(byte[0]);
+      }
+      serde_json::from_slice(&line).unwrap()
+    };
+
+    let first = UnixStream::connect(&path).unwrap();
+    let first_grant = read_grant(&first);
+    assert_eq!(first_grant["base"], 0);
+    assert_eq!(first_grant["format"], "ndjson-crap/1");
+
+    let second = UnixStream::connect(&path).unwrap();
+    assert_eq!(read_grant(&second)["base"], u64::from(u32::MAX) + 1);
+
+    (&first)
+      .write_all(b"{\"type\":\"plan\",\"count\":1}\n")
+      .unwrap();
+    (&second)
+      .write_all(b"{\"type\":\"node_start\",\"tp\":4294967297}\n")
+      .unwrap();
+    drop(first);
+    drop(second);
+    // Dropping the write end EOFs the lease; the server drains the
+    // already-buffered lines, flushes, and exits 0.
+    // SAFETY: we own the write end and have not closed it elsewhere.
+    unsafe { libc::close(lease_fds[1]) };
+    assert_eq!(server.join().unwrap(), EXIT_SUCCESS);
+
+    let merged = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    let mut lines: Vec<&str> = merged.lines().collect();
+    lines.sort_unstable();
+    assert_eq!(
+      lines,
+      vec![
+        "{\"type\":\"node_start\",\"tp\":4294967297}",
+        "{\"type\":\"plan\",\"count\":1}",
+      ],
+    );
+  }
+}

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -524,6 +524,14 @@ impl<'src, 'run> Evaluator<'src, 'run> {
       cmd.env(key, value);
     }
 
+    // This child's stdout is consumed as *data* (backticks, shell()),
+    // so withdraw any crap RFC 0002 offer tunneling through our
+    // environment: a producer attaching here — stdout is the default
+    // channel — would leak ndjson-crap records into the value.
+    for var in EventSink::OFFER_VARS {
+      cmd.env_remove(var);
+    }
+
     cmd.output_guard_stdout()
   }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,6 @@
 use {
   super::*,
-  std::sync::atomic::{AtomicUsize, Ordering},
+  std::sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 /// One record on the `--events-fd` stream.
@@ -12,6 +12,18 @@ use {
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum Event<'a> {
+  /// The crap RFC 0002 *hello*: announces attachment, the negotiated
+  /// format, and this producer's position in the harness's node tree.
+  /// Emitted once, before any other record, when the sink was
+  /// activated by an ambient `CRAP=2` offer (never under explicit
+  /// `--events-fd`, whose RFC 0002 contract pins `plan` first).
+  Crap {
+    version: u32,
+    ndjson: u32,
+    format: &'a str,
+    producer: &'a str,
+    parent: Option<usize>,
+  },
   Plan {
     version: u32,
     recipe_count: usize,
@@ -60,26 +72,123 @@ pub(crate) enum OutputDataFormat {
 
 const SCHEMA_VERSION: u32 = 1;
 
+/// CRAP major version this producer can attach to (crap RFC 0002).
+const CRAP_VERSION: &str = "2";
+
+/// The one format token this producer emits. Negotiation selects the
+/// first token in `CRAP_ACCEPT` (harness preference order) we support.
+const NDJSON_CRAP_1: &str = "ndjson-crap/1";
+
+/// Maximum bytes of UTF-8 text per `output` record `data` field.
+/// crap RFC 0002 §7 requires each serialized record to fit one
+/// `write(2)` of at most `PIPE_BUF` (4096) bytes on a shared channel;
+/// 1024 pre-escaping bytes leave headroom for JSON escaping and the
+/// record envelope.
+pub(crate) const OUTPUT_CHUNK_BYTES: usize = 1024;
+
+/// Split `data` into chunks of at most `max_bytes` bytes, each on a
+/// char boundary. `max_bytes` must be at least 4 (the maximum UTF-8
+/// sequence length) or a multi-byte char could stall progress.
+pub(crate) fn chunk_str(mut data: &str, max_bytes: usize) -> impl Iterator<Item = &str> {
+  std::iter::from_fn(move || {
+    if data.is_empty() {
+      return None;
+    }
+    let mut end = data.len().min(max_bytes);
+    while !data.is_char_boundary(end) {
+      end -= 1;
+    }
+    let (chunk, rest) = data.split_at(end);
+    data = rest;
+    Some(chunk)
+  })
+}
+
+/// Random node-id base for ambient attachment, per crap RFC 0002 §7:
+/// a shared channel may carry several producers, so ids are drawn
+/// from a uniformly random base in `[2^40, 2^48)` (JSON-exact, never
+/// colliding with an explicit-flag producer's small monotonic ids).
+/// `RandomState` is seeded from OS randomness per process, which is
+/// all the uniformity the collision argument needs.
+fn random_tp_base() -> usize {
+  use std::hash::{BuildHasher, Hasher, RandomState};
+  let mut hasher = RandomState::new().build_hasher();
+  hasher.write_u32(std::process::id());
+  let r = hasher.finish();
+  if usize::BITS >= 64 {
+    usize::try_from((1u64 << 40) + (r % ((1u64 << 48) - (1u64 << 40)))).unwrap_or(usize::MAX >> 1)
+  } else {
+    // 32-bit targets: keep ids large but in range.
+    usize::try_from((1u64 << 28) + (r % (1u64 << 30))).unwrap_or(usize::MAX >> 1)
+  }
+}
+
+/// Select the first format token in a `CRAP_ACCEPT` list we support.
+/// Token grammar (crap RFC 0002 §4): `name/major[;param=value]*`,
+/// comma-separated, harness preference order. Parameters are ignored.
+fn negotiate(accept: &str) -> Option<&'static str> {
+  for token in accept.split(',') {
+    let name_version = token.split(';').next().unwrap_or("").trim();
+    if name_version == NDJSON_CRAP_1 {
+      return Some(NDJSON_CRAP_1);
+    }
+  }
+  None
+}
+
+/// Ambient-attach state (crap RFC 0002). Present only when the sink
+/// was activated by a `CRAP=2` environment offer.
+struct AmbientAttach {
+  /// `CRAP_DEPTH`: depth to assign our root recipes.
+  depth_base: u32,
+  /// The hello is written lazily before the first record, so silent
+  /// invocations (`--list`, …) stay silent on the channel.
+  hello_sent: AtomicBool,
+  /// `CRAP_PARENT`: harness node id our root recipes nest under.
+  parent: Option<usize>,
+}
+
 /// Sink that serializes `Event` records to a writer as one JSON record
 /// per line. When constructed with `EventSink::noop()`, all `emit`
 /// calls are no-ops; this lets the normal code path call `emit`
 /// unconditionally without paying allocation cost when `--events-fd`
 /// is not set.
 pub(crate) struct EventSink {
-  writer: Option<Mutex<Box<dyn Write + Send>>>,
-  /// Monotonic test-point counter. `next_tp` returns one-based tp
-  /// values; the upper bound matches the `recipe_count` announced
-  /// in the leading `plan` event (per RFC 0002 §Plan Record). Shared
-  /// across threads via atomic — parallel dep execution still gets
-  /// distinct tp values.
+  /// Present iff the sink was activated by an ambient `CRAP=2`
+  /// offer rather than the explicit `--events-fd` flag.
+  ambient: Option<AmbientAttach>,
+  /// Test-point counter. `next_tp` returns `base + n` values, one-
+  /// based; the base is 0 for explicit `--events-fd` sinks (so tps
+  /// stay 1..n per RFC 0002) and random for ambient sinks (crap
+  /// RFC 0002 §7). Shared across threads via atomic — parallel dep
+  /// execution still gets distinct tp values.
   next_tp: AtomicUsize,
+  /// A `dup(2)` of the channel that recipe children can inherit
+  /// (`FD_CLOEXEC` clear), named in the `CRAP_FD` re-offer. `None`
+  /// when the sink is inactive or the dup failed — then no re-offer
+  /// is made.
+  reoffer_fd: Option<i32>,
+  writer: Option<Mutex<Box<dyn Write + Send>>>,
 }
 
 impl EventSink {
+  /// Environment variables forming a crap RFC 0002 offer. An aware
+  /// program either re-offers (rewriting all of them) or withdraws
+  /// (removing all of them) for each child it executes.
+  pub(crate) const OFFER_VARS: [&'static str; 5] = [
+    "CRAP",
+    "CRAP_FD",
+    "CRAP_ACCEPT",
+    "CRAP_PARENT",
+    "CRAP_DEPTH",
+  ];
+
   pub(crate) fn noop() -> Self {
     Self {
       writer: None,
       next_tp: AtomicUsize::new(0),
+      reoffer_fd: None,
+      ambient: None,
     }
   }
 
@@ -87,6 +196,8 @@ impl EventSink {
     Self {
       writer: Some(Mutex::new(Box::new(writer))),
       next_tp: AtomicUsize::new(0),
+      reoffer_fd: None,
+      ambient: None,
     }
   }
 
@@ -109,12 +220,25 @@ impl EventSink {
     #[cfg(unix)]
     {
       use std::os::fd::FromRawFd;
+      // Dup the channel before taking ownership, so recipe children
+      // can be handed a descriptor that reaches it even when their
+      // own stdio is repointed at capture pipes (crap RFC 0002
+      // §6.1). dup'd descriptors have FD_CLOEXEC clear, so children
+      // inherit it. A failed dup just disables the re-offer.
+      // SAFETY: `dup` has no memory-safety preconditions; `fd` was
+      // validated above and a failure returns -1, handled below.
+      let reoffer = unsafe { libc::dup(fd) };
       // SAFETY: `validate_fd` succeeded, so `fd` is an open writable
       // file descriptor. We assume sole ownership for the lifetime
       // of this `EventSink`; the wrapped `File` will close `fd` on
       // drop.
       let file = unsafe { File::from_raw_fd(fd) };
-      Ok(Self::from_writer(file))
+      Ok(Self {
+        writer: Some(Mutex::new(Box::new(file))),
+        next_tp: AtomicUsize::new(0),
+        reoffer_fd: (reoffer >= 0).then_some(reoffer),
+        ambient: None,
+      })
     }
     #[cfg(not(unix))]
     {
@@ -125,12 +249,118 @@ impl EventSink {
     }
   }
 
+  /// Build an `EventSink` from an ambient crap RFC 0002 offer in the
+  /// environment (`CRAP=2` plus optional `CRAP_FD`/`CRAP_ACCEPT`/
+  /// `CRAP_PARENT`/`CRAP_DEPTH`). Per §3 of the RFC, every failure
+  /// mode — absent or unsupported version, unsupported format list,
+  /// malformed or dead descriptor — degrades silently to a noop
+  /// sink; only the explicit `--events-fd` flag errors.
+  pub(crate) fn from_ambient() -> Self {
+    #[cfg(unix)]
+    {
+      use std::os::fd::FromRawFd;
+
+      fn parse_var<T: FromStr>(name: &str) -> Option<T> {
+        env::var(name).ok().and_then(|v| v.trim().parse().ok())
+      }
+
+      let Ok(version) = env::var("CRAP") else {
+        return Self::noop();
+      };
+      if version.trim() != CRAP_VERSION {
+        return Self::noop();
+      }
+      let accept = env::var("CRAP_ACCEPT").unwrap_or_else(|_| NDJSON_CRAP_1.into());
+      if negotiate(&accept).is_none() {
+        return Self::noop();
+      }
+      let fd = match env::var("CRAP_FD") {
+        Ok(value) => match value.trim().parse::<i32>() {
+          Ok(fd) => fd,
+          Err(_) => return Self::noop(),
+        },
+        // Default channel: stdout (crap RFC 0002 §2).
+        Err(_) => 1,
+      };
+      if Self::validate_fd(fd).is_err() {
+        return Self::noop();
+      }
+      // Own a dup rather than the descriptor itself: the default
+      // channel is stdout, which must survive this sink's drop.
+      // SAFETY: `dup` has no memory-safety preconditions; `fd` was
+      // validated above and a failure returns -1, handled below.
+      let owned = unsafe { libc::dup(fd) };
+      if owned < 0 {
+        return Self::noop();
+      }
+      // SAFETY: as above; a failed dup only disables the re-offer.
+      let reoffer = unsafe { libc::dup(fd) };
+      // SAFETY: `owned` is a fresh dup of a validated writable fd,
+      // owned exclusively by the wrapped `File`.
+      let file = unsafe { File::from_raw_fd(owned) };
+      Self {
+        writer: Some(Mutex::new(Box::new(file))),
+        next_tp: AtomicUsize::new(random_tp_base()),
+        reoffer_fd: (reoffer >= 0).then_some(reoffer),
+        ambient: Some(AmbientAttach {
+          parent: parse_var("CRAP_PARENT"),
+          depth_base: parse_var("CRAP_DEPTH").unwrap_or(0),
+          hello_sent: AtomicBool::new(false),
+        }),
+      }
+    }
+    #[cfg(not(unix))]
+    {
+      Self::noop()
+    }
+  }
+
+  /// `CRAP_PARENT` of the ambient offer: the harness node id that
+  /// top-level recipe nodes carry as `parent` (crap RFC 0002 §7).
+  pub(crate) fn root_parent(&self) -> Option<usize> {
+    self.ambient.as_ref().and_then(|ambient| ambient.parent)
+  }
+
+  /// `CRAP_DEPTH` of the ambient offer: added to recipe depths so
+  /// the emitted tree continues the harness's depth numbering.
+  pub(crate) fn depth_base(&self) -> u32 {
+    self
+      .ambient
+      .as_ref()
+      .map_or(0, |ambient| ambient.depth_base)
+  }
+
+  /// The environment for re-offering the protocol to a recipe child
+  /// (crap RFC 0002 §6.1 passthrough): same channel via the dup'd
+  /// descriptor, accept list narrowed to the negotiated format, and
+  /// the child scoped under this recipe's node. `None` when the sink
+  /// is inactive (the child sees the inherited environment
+  /// untouched) or when no inheritable descriptor is available.
+  pub(crate) fn reoffer_env(&self, tp: usize, depth: u32) -> Option<Vec<(String, String)>> {
+    if !self.is_active() {
+      return None;
+    }
+    let fd = self.reoffer_fd?;
+    Some(vec![
+      ("CRAP".into(), CRAP_VERSION.into()),
+      ("CRAP_FD".into(), fd.to_string()),
+      ("CRAP_ACCEPT".into(), NDJSON_CRAP_1.into()),
+      ("CRAP_PARENT".into(), tp.to_string()),
+      (
+        "CRAP_DEPTH".into(),
+        (self.depth_base() + depth + 1).to_string(),
+      ),
+    ])
+  }
+
   #[cfg(unix)]
   fn validate_fd(fd: i32) -> io::Result<()> {
     // `fcntl(fd, F_GETFL)` returns the file's status flags or -1
     // with errno set (EBADF for a closed fd, EINVAL for some
     // unsupported descriptor types). We use that to gate ownership
     // before wrapping the raw fd in a File.
+    // SAFETY: `F_GETFL` reads descriptor state only; an invalid fd
+    // yields -1 with errno set, handled below.
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
     if flags == -1 {
       return Err(io::Error::last_os_error());
@@ -161,20 +391,49 @@ impl EventSink {
   /// silently dropped: an unwritable events fd does not abort recipe
   /// execution, but the activation check at startup is expected to
   /// catch dead descriptors before any recipe runs.
+  ///
+  /// Each record is serialized to a buffer and written with a single
+  /// `write_all`, so records from other producers sharing the channel
+  /// (crap RFC 0002 §7) never interleave mid-line as long as every
+  /// record fits `PIPE_BUF`.
   pub(crate) fn emit(&self, event: &Event<'_>) {
     let Some(writer) = &self.writer else { return };
+    let Ok(mut line) = serde_json::to_vec(event) else {
+      return;
+    };
+    line.push(b'\n');
     let mut guard = match writer.lock() {
       Ok(guard) => guard,
       Err(_) => return,
     };
-    if serde_json::to_writer(&mut *guard, event).is_err() {
-      return;
+    // Ambient attachment announces with a hello before its first
+    // record (crap RFC 0002 §5).
+    if let Some(ambient) = &self.ambient {
+      if !ambient.hello_sent.swap(true, Ordering::Relaxed) {
+        let hello = Event::Crap {
+          version: 2,
+          ndjson: SCHEMA_VERSION,
+          format: NDJSON_CRAP_1,
+          producer: concat!("just-us/", env!("CARGO_PKG_VERSION")),
+          parent: ambient.parent,
+        };
+        if let Ok(mut hello_line) = serde_json::to_vec(&hello) {
+          hello_line.push(b'\n');
+          let _ = guard.write_all(&hello_line);
+        }
+      }
     }
-    let _ = guard.write_all(b"\n");
+    let _ = guard.write_all(&line);
     let _ = guard.flush();
   }
 
   pub(crate) fn emit_plan(&self, recipe_count: usize) {
+    // A producer attached under a harness node must not emit
+    // stream-global records (crap RFC 0002 §7): the plan would
+    // re-arm the consumer's progress accounting mid-stream.
+    if self.root_parent().is_some() {
+      return;
+    }
     self.emit(&Event::Plan {
       version: SCHEMA_VERSION,
       recipe_count,
@@ -293,6 +552,124 @@ mod tests {
       out,
       "{\"type\":\"output\",\"tp\":1,\"stream\":\"stdout\",\
        \"format\":\"utf8\",\"data\":\"hello\\n\"}\n"
+    );
+  }
+
+  fn ambient_sink<W: Write + Send + 'static>(writer: W, parent: Option<usize>) -> EventSink {
+    EventSink {
+      writer: Some(Mutex::new(Box::new(writer))),
+      next_tp: AtomicUsize::new(random_tp_base()),
+      reoffer_fd: None,
+      ambient: Some(AmbientAttach {
+        parent,
+        depth_base: 0,
+        hello_sent: AtomicBool::new(false),
+      }),
+    }
+  }
+
+  #[test]
+  fn negotiate_picks_first_supported_token() {
+    assert_eq!(negotiate("ndjson-crap/1"), Some("ndjson-crap/1"));
+    assert_eq!(
+      negotiate("crap-pack/1, ndjson-crap/1;families=execution+result"),
+      Some("ndjson-crap/1"),
+    );
+    assert_eq!(negotiate("crap-pack/1"), None);
+    assert_eq!(negotiate("ndjson-crap/2"), None);
+    assert_eq!(negotiate(""), None);
+  }
+
+  #[test]
+  fn random_tp_base_is_in_shared_channel_range() {
+    for _ in 0..16 {
+      let base = random_tp_base();
+      assert!(base >= 1 << 40, "base {base} below 2^40");
+      assert!(base < 1 << 48, "base {base} at or above 2^48");
+    }
+  }
+
+  #[test]
+  fn chunk_str_splits_on_char_boundaries() {
+    let chunks: Vec<&str> = chunk_str("hello", 2).collect();
+    assert_eq!(chunks, vec!["he", "ll", "o"]);
+    // U+FFFD is three bytes; a 4-byte budget must not split it.
+    let data = "a\u{fffd}b";
+    let chunks: Vec<&str> = chunk_str(data, 4).collect();
+    assert_eq!(chunks.concat(), data);
+    for chunk in chunks {
+      assert!(chunk.len() <= 4);
+    }
+    assert_eq!(chunk_str("", 4).count(), 0);
+  }
+
+  #[test]
+  fn ambient_hello_precedes_first_record() {
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    {
+      let sink = ambient_sink(BufHandle(Arc::clone(&buf)), Some(7));
+      sink.emit(&Event::RecipeCommand {
+        tp: 1,
+        command: "echo hi",
+        line: 1,
+      });
+    }
+    let bytes = Arc::try_unwrap(buf).unwrap().into_inner().unwrap();
+    let out = String::from_utf8(bytes).unwrap();
+    let mut lines = out.lines();
+    let hello = lines.next().unwrap();
+    assert_eq!(
+      hello,
+      format!(
+        "{{\"type\":\"crap\",\"version\":2,\"ndjson\":1,\
+         \"format\":\"ndjson-crap/1\",\"producer\":\"just-us/{}\",\
+         \"parent\":7}}",
+        env!("CARGO_PKG_VERSION"),
+      ),
+    );
+    assert!(
+      lines
+        .next()
+        .unwrap()
+        .starts_with("{\"type\":\"recipe_command\"")
+    );
+    assert!(lines.next().is_none());
+  }
+
+  #[test]
+  fn nested_attachment_suppresses_plan() {
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    {
+      let sink = ambient_sink(BufHandle(Arc::clone(&buf)), Some(7));
+      sink.emit_plan(3);
+    }
+    let bytes = Arc::try_unwrap(buf).unwrap().into_inner().unwrap();
+    assert!(bytes.is_empty(), "nested plan must be suppressed");
+  }
+
+  #[test]
+  fn root_attachment_emits_hello_then_plan() {
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    {
+      let sink = ambient_sink(BufHandle(Arc::clone(&buf)), None);
+      sink.emit_plan(3);
+    }
+    let bytes = Arc::try_unwrap(buf).unwrap().into_inner().unwrap();
+    let out = String::from_utf8(bytes).unwrap();
+    let mut lines = out.lines();
+    assert!(lines.next().unwrap().starts_with("{\"type\":\"crap\""));
+    assert_eq!(
+      lines.next().unwrap(),
+      "{\"type\":\"plan\",\"version\":1,\"recipe_count\":3}",
+    );
+  }
+
+  #[test]
+  fn explicit_sink_emits_no_hello() {
+    let out = capture(|s| s.emit_plan(2));
+    assert_eq!(
+      out,
+      "{\"type\":\"plan\",\"version\":1,\"recipe_count\":2}\n"
     );
   }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,6 @@
 use {
   super::*,
-  std::sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+  std::sync::atomic::{AtomicUsize, Ordering},
 };
 
 /// One record on the `--events-fd` stream.
@@ -12,18 +12,6 @@ use {
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum Event<'a> {
-  /// The crap RFC 0002 *hello*: announces attachment, the negotiated
-  /// format, and this producer's position in the harness's node tree.
-  /// Emitted once, before any other record, when the sink was
-  /// activated by an ambient `CRAP=2` offer (never under explicit
-  /// `--events-fd`, whose RFC 0002 contract pins `plan` first).
-  Crap {
-    version: u32,
-    ndjson: u32,
-    format: &'a str,
-    producer: &'a str,
-    parent: Option<usize>,
-  },
   Plan {
     version: u32,
     recipe_count: usize,
@@ -72,19 +60,12 @@ pub(crate) enum OutputDataFormat {
 
 const SCHEMA_VERSION: u32 = 1;
 
-/// CRAP major version this producer can attach to (crap RFC 0002).
-const CRAP_VERSION: &str = "2";
-
-/// The one format token this producer emits. Negotiation selects the
-/// first token in `CRAP_ACCEPT` (harness preference order) we support.
-const NDJSON_CRAP_1: &str = "ndjson-crap/1";
-
 /// Maximum bytes of UTF-8 text per `output` record `data` field.
-/// crap RFC 0002 §7 requires each serialized record to fit one
-/// `write(2)` of at most `PIPE_BUF` (4096) bytes on a shared channel;
-/// 1024 pre-escaping bytes leave headroom for JSON escaping and the
-/// record envelope.
-pub(crate) const OUTPUT_CHUNK_BYTES: usize = 1024;
+/// crap RFC 0002 §5 asks producers to keep serialized record lines
+/// under 64 KiB as buffer hygiene for the sink server; 8 KiB of
+/// pre-escaping text stays under that even at worst-case JSON
+/// escaping (6 output bytes per input byte).
+pub(crate) const OUTPUT_CHUNK_BYTES: usize = 8192;
 
 /// Split `data` into chunks of at most `max_bytes` bytes, each on a
 /// char boundary. `max_bytes` must be at least 4 (the maximum UTF-8
@@ -104,105 +85,60 @@ pub(crate) fn chunk_str(mut data: &str, max_bytes: usize) -> impl Iterator<Item 
   })
 }
 
-/// Random node-id base for ambient attachment, per crap RFC 0002 §7:
-/// a shared channel may carry several producers, so ids are drawn
-/// from a uniformly random base in `[2^40, 2^48)` (JSON-exact, never
-/// colliding with an explicit-flag producer's small monotonic ids).
-/// `RandomState` is seeded from OS randomness per process, which is
-/// all the uniformity the collision argument needs.
-fn random_tp_base() -> usize {
-  use std::hash::{BuildHasher, Hasher, RandomState};
-  let mut hasher = RandomState::new().build_hasher();
-  hasher.write_u32(std::process::id());
-  let r = hasher.finish();
-  if usize::BITS >= 64 {
-    usize::try_from((1u64 << 40) + (r % ((1u64 << 48) - (1u64 << 40)))).unwrap_or(usize::MAX >> 1)
-  } else {
-    // 32-bit targets: keep ids large but in range.
-    usize::try_from((1u64 << 28) + (r % (1u64 << 30))).unwrap_or(usize::MAX >> 1)
-  }
-}
-
-/// Select the first format token in a `CRAP_ACCEPT` list we support.
-/// Token grammar (crap RFC 0002 §4): `name/major[;param=value]*`,
-/// comma-separated, harness preference order. Parameters are ignored.
-fn negotiate(accept: &str) -> Option<&'static str> {
-  for token in accept.split(',') {
-    let name_version = token.split(';').next().unwrap_or("").trim();
-    if name_version == NDJSON_CRAP_1 {
-      return Some(NDJSON_CRAP_1);
-    }
-  }
-  None
-}
-
 /// Ambient-attach state (crap RFC 0002). Present only when the sink
-/// was activated by a `CRAP=2` environment offer.
+/// was reached via a `CRAP=2` environment offer — either inherited
+/// (`CRAP_SINK`) or root-elected (we birthed the server).
 struct AmbientAttach {
-  /// `CRAP_DEPTH`: depth to assign our root recipes.
-  depth_base: u32,
-  /// The hello is written lazily before the first record, so silent
-  /// invocations (`--list`, …) stay silent on the channel.
-  hello_sent: AtomicBool,
   /// `CRAP_PARENT`: harness node id our root recipes nest under.
   parent: Option<usize>,
+  /// The sink's socket path, re-exported to recipe children so they
+  /// connect themselves (crap RFC 0002 §5).
+  sink_path: String,
 }
 
 /// Sink that serializes `Event` records to a writer as one JSON record
 /// per line. When constructed with `EventSink::noop()`, all `emit`
 /// calls are no-ops; this lets the normal code path call `emit`
-/// unconditionally without paying allocation cost when `--events-fd`
-/// is not set.
+/// unconditionally without paying allocation cost when neither
+/// `--events-fd` nor a CRAP offer is active.
 pub(crate) struct EventSink {
   /// Present iff the sink was activated by an ambient `CRAP=2`
   /// offer rather than the explicit `--events-fd` flag.
   ambient: Option<AmbientAttach>,
   /// Test-point counter. `next_tp` returns `base + n` values, one-
   /// based; the base is 0 for explicit `--events-fd` sinks (so tps
-  /// stay 1..n per RFC 0002) and random for ambient sinks (crap
-  /// RFC 0002 §7). Shared across threads via atomic — parallel dep
-  /// execution still gets distinct tp values.
+  /// stay 1..n per RFC 0002) and the sink server's granted base for
+  /// ambient sinks (crap RFC 0002 §4). Shared across threads via
+  /// atomic — parallel dep execution still gets distinct tp values.
   next_tp: AtomicUsize,
-  /// A `dup(2)` of the channel that recipe children can inherit
-  /// (`FD_CLOEXEC` clear), named in the `CRAP_FD` re-offer. `None`
-  /// when the sink is inactive or the dup failed — then no re-offer
-  /// is made.
-  reoffer_fd: Option<i32>,
   writer: Option<Mutex<Box<dyn Write + Send>>>,
 }
 
 impl EventSink {
   /// Environment variables forming a crap RFC 0002 offer. An aware
-  /// program either re-offers (rewriting all of them) or withdraws
-  /// (removing all of them) for each child it executes.
-  pub(crate) const OFFER_VARS: [&'static str; 5] = [
-    "CRAP",
-    "CRAP_FD",
-    "CRAP_ACCEPT",
-    "CRAP_PARENT",
-    "CRAP_DEPTH",
-  ];
+  /// program either scopes them per child (`CRAP_PARENT`) or
+  /// withdraws all of them for children whose stdout it consumes as
+  /// data.
+  pub(crate) const OFFER_VARS: [&'static str; 3] = ["CRAP", "CRAP_SINK", "CRAP_PARENT"];
 
   pub(crate) fn noop() -> Self {
     Self {
-      writer: None,
-      next_tp: AtomicUsize::new(0),
-      reoffer_fd: None,
       ambient: None,
+      next_tp: AtomicUsize::new(0),
+      writer: None,
     }
   }
 
   pub(crate) fn from_writer<W: Write + Send + 'static>(writer: W) -> Self {
     Self {
-      writer: Some(Mutex::new(Box::new(writer))),
-      next_tp: AtomicUsize::new(0),
-      reoffer_fd: None,
       ambient: None,
+      next_tp: AtomicUsize::new(0),
+      writer: Some(Mutex::new(Box::new(writer))),
     }
   }
 
-  /// Allocate the next test-point number. Returns a one-based
-  /// integer; the first call returns 1.
+  /// Allocate the next test-point number. Returns base + a one-based
+  /// counter; the first call returns base + 1.
   pub(crate) fn next_tp(&self) -> usize {
     self.next_tp.fetch_add(1, Ordering::Relaxed) + 1
   }
@@ -220,25 +156,12 @@ impl EventSink {
     #[cfg(unix)]
     {
       use std::os::fd::FromRawFd;
-      // Dup the channel before taking ownership, so recipe children
-      // can be handed a descriptor that reaches it even when their
-      // own stdio is repointed at capture pipes (crap RFC 0002
-      // §6.1). dup'd descriptors have FD_CLOEXEC clear, so children
-      // inherit it. A failed dup just disables the re-offer.
-      // SAFETY: `dup` has no memory-safety preconditions; `fd` was
-      // validated above and a failure returns -1, handled below.
-      let reoffer = unsafe { libc::dup(fd) };
       // SAFETY: `validate_fd` succeeded, so `fd` is an open writable
       // file descriptor. We assume sole ownership for the lifetime
       // of this `EventSink`; the wrapped `File` will close `fd` on
       // drop.
       let file = unsafe { File::from_raw_fd(fd) };
-      Ok(Self {
-        writer: Some(Mutex::new(Box::new(file))),
-        next_tp: AtomicUsize::new(0),
-        reoffer_fd: (reoffer >= 0).then_some(reoffer),
-        ambient: None,
-      })
+      Ok(Self::from_writer(file))
     }
     #[cfg(not(unix))]
     {
@@ -249,64 +172,25 @@ impl EventSink {
     }
   }
 
-  /// Build an `EventSink` from an ambient crap RFC 0002 offer in the
-  /// environment (`CRAP=2` plus optional `CRAP_FD`/`CRAP_ACCEPT`/
-  /// `CRAP_PARENT`/`CRAP_DEPTH`). Per §3 of the RFC, every failure
-  /// mode — absent or unsupported version, unsupported format list,
-  /// malformed or dead descriptor — degrades silently to a noop
-  /// sink; only the explicit `--events-fd` flag errors.
+  /// Build an `EventSink` from an ambient crap RFC 0002 offer:
+  /// connect to the inherited `CRAP_SINK`, or — as a root-capable
+  /// node — birth a sink server and connect to it
+  /// (`crap_attach::attach`). Per §3 of the RFC, every failure mode
+  /// degrades silently to a noop sink; only the explicit
+  /// `--events-fd` flag errors.
   pub(crate) fn from_ambient() -> Self {
     #[cfg(unix)]
     {
-      use std::os::fd::FromRawFd;
-
-      fn parse_var<T: FromStr>(name: &str) -> Option<T> {
-        env::var(name).ok().and_then(|v| v.trim().parse().ok())
-      }
-
-      let Ok(version) = env::var("CRAP") else {
-        return Self::noop();
-      };
-      if version.trim() != CRAP_VERSION {
-        return Self::noop();
-      }
-      let accept = env::var("CRAP_ACCEPT").unwrap_or_else(|_| NDJSON_CRAP_1.into());
-      if negotiate(&accept).is_none() {
-        return Self::noop();
-      }
-      let fd = match env::var("CRAP_FD") {
-        Ok(value) => match value.trim().parse::<i32>() {
-          Ok(fd) => fd,
-          Err(_) => return Self::noop(),
+      match crap_attach::attach() {
+        Some(attachment) => Self {
+          ambient: Some(AmbientAttach {
+            parent: attachment.parent,
+            sink_path: attachment.sink_path,
+          }),
+          next_tp: AtomicUsize::new(attachment.base),
+          writer: Some(Mutex::new(Box::new(attachment.stream))),
         },
-        // Default channel: stdout (crap RFC 0002 §2).
-        Err(_) => 1,
-      };
-      if Self::validate_fd(fd).is_err() {
-        return Self::noop();
-      }
-      // Own a dup rather than the descriptor itself: the default
-      // channel is stdout, which must survive this sink's drop.
-      // SAFETY: `dup` has no memory-safety preconditions; `fd` was
-      // validated above and a failure returns -1, handled below.
-      let owned = unsafe { libc::dup(fd) };
-      if owned < 0 {
-        return Self::noop();
-      }
-      // SAFETY: as above; a failed dup only disables the re-offer.
-      let reoffer = unsafe { libc::dup(fd) };
-      // SAFETY: `owned` is a fresh dup of a validated writable fd,
-      // owned exclusively by the wrapped `File`.
-      let file = unsafe { File::from_raw_fd(owned) };
-      Self {
-        writer: Some(Mutex::new(Box::new(file))),
-        next_tp: AtomicUsize::new(random_tp_base()),
-        reoffer_fd: (reoffer >= 0).then_some(reoffer),
-        ambient: Some(AmbientAttach {
-          parent: parse_var("CRAP_PARENT"),
-          depth_base: parse_var("CRAP_DEPTH").unwrap_or(0),
-          hello_sent: AtomicBool::new(false),
-        }),
+        None => Self::noop(),
       }
     }
     #[cfg(not(unix))]
@@ -316,40 +200,25 @@ impl EventSink {
   }
 
   /// `CRAP_PARENT` of the ambient offer: the harness node id that
-  /// top-level recipe nodes carry as `parent` (crap RFC 0002 §7).
+  /// top-level recipe nodes carry as `parent`.
   pub(crate) fn root_parent(&self) -> Option<usize> {
     self.ambient.as_ref().and_then(|ambient| ambient.parent)
   }
 
-  /// `CRAP_DEPTH` of the ambient offer: added to recipe depths so
-  /// the emitted tree continues the harness's depth numbering.
-  pub(crate) fn depth_base(&self) -> u32 {
-    self
-      .ambient
-      .as_ref()
-      .map_or(0, |ambient| ambient.depth_base)
-  }
-
-  /// The environment for re-offering the protocol to a recipe child
-  /// (crap RFC 0002 §6.1 passthrough): same channel via the dup'd
-  /// descriptor, accept list narrowed to the negotiated format, and
-  /// the child scoped under this recipe's node. `None` when the sink
-  /// is inactive (the child sees the inherited environment
-  /// untouched) or when no inheritable descriptor is available.
-  pub(crate) fn reoffer_env(&self, tp: usize, depth: u32) -> Option<Vec<(String, String)>> {
-    if !self.is_active() {
-      return None;
-    }
-    let fd = self.reoffer_fd?;
+  /// The environment for scoping a recipe child into our tree (crap
+  /// RFC 0002 §5): the inherited offer and sink address, with
+  /// `CRAP_PARENT` set to the child's execution node so a crap-aware
+  /// child connects itself and nests; anything else emits garbage,
+  /// which the capture path wraps as `output` records. `None` when
+  /// the sink is not ambient (explicit `--events-fd` has no socket
+  /// for children to connect to; the child sees the inherited
+  /// environment untouched).
+  pub(crate) fn reoffer_env(&self, tp: usize) -> Option<Vec<(String, String)>> {
+    let ambient = self.ambient.as_ref()?;
     Some(vec![
-      ("CRAP".into(), CRAP_VERSION.into()),
-      ("CRAP_FD".into(), fd.to_string()),
-      ("CRAP_ACCEPT".into(), NDJSON_CRAP_1.into()),
+      ("CRAP".into(), "2".into()),
+      ("CRAP_SINK".into(), ambient.sink_path.clone()),
       ("CRAP_PARENT".into(), tp.to_string()),
-      (
-        "CRAP_DEPTH".into(),
-        (self.depth_base() + depth + 1).to_string(),
-      ),
     ])
   }
 
@@ -388,14 +257,13 @@ impl EventSink {
   }
 
   /// Serialize `event` as one JSON line on the wire. Errors are
-  /// silently dropped: an unwritable events fd does not abort recipe
-  /// execution, but the activation check at startup is expected to
-  /// catch dead descriptors before any recipe runs.
+  /// silently dropped: an unwritable sink does not abort recipe
+  /// execution (crap RFC 0002 §3 step 4 / eng RFC 0002 write-failure
+  /// policy).
   ///
   /// Each record is serialized to a buffer and written with a single
-  /// `write_all`, so records from other producers sharing the channel
-  /// (crap RFC 0002 §7) never interleave mid-line as long as every
-  /// record fits `PIPE_BUF`.
+  /// `write_all`; per-connection framing at the sink server keeps it
+  /// whole regardless.
   pub(crate) fn emit(&self, event: &Event<'_>) {
     let Some(writer) = &self.writer else { return };
     let Ok(mut line) = serde_json::to_vec(event) else {
@@ -406,31 +274,14 @@ impl EventSink {
       Ok(guard) => guard,
       Err(_) => return,
     };
-    // Ambient attachment announces with a hello before its first
-    // record (crap RFC 0002 §5).
-    if let Some(ambient) = &self.ambient {
-      if !ambient.hello_sent.swap(true, Ordering::Relaxed) {
-        let hello = Event::Crap {
-          version: 2,
-          ndjson: SCHEMA_VERSION,
-          format: NDJSON_CRAP_1,
-          producer: concat!("just-us/", env!("CARGO_PKG_VERSION")),
-          parent: ambient.parent,
-        };
-        if let Ok(mut hello_line) = serde_json::to_vec(&hello) {
-          hello_line.push(b'\n');
-          let _ = guard.write_all(&hello_line);
-        }
-      }
-    }
     let _ = guard.write_all(&line);
     let _ = guard.flush();
   }
 
   pub(crate) fn emit_plan(&self, recipe_count: usize) {
-    // A producer attached under a harness node must not emit
-    // stream-global records (crap RFC 0002 §7): the plan would
-    // re-arm the consumer's progress accounting mid-stream.
+    // A producer attached under a harness node does not emit
+    // stream-global records: a nested plan would re-arm the
+    // consumer's progress accounting mid-stream.
     if self.root_parent().is_some() {
       return;
     }
@@ -471,6 +322,21 @@ mod tests {
 
     fn flush(&mut self) -> io::Result<()> {
       Ok(())
+    }
+  }
+
+  fn ambient_sink<W: Write + Send + 'static>(
+    writer: W,
+    base: usize,
+    parent: Option<usize>,
+  ) -> EventSink {
+    EventSink {
+      ambient: Some(AmbientAttach {
+        parent,
+        sink_path: "/run/crap/test.sock".into(),
+      }),
+      next_tp: AtomicUsize::new(base),
+      writer: Some(Mutex::new(Box::new(writer))),
     }
   }
 
@@ -555,38 +421,22 @@ mod tests {
     );
   }
 
-  fn ambient_sink<W: Write + Send + 'static>(writer: W, parent: Option<usize>) -> EventSink {
-    EventSink {
-      writer: Some(Mutex::new(Box::new(writer))),
-      next_tp: AtomicUsize::new(random_tp_base()),
-      reoffer_fd: None,
-      ambient: Some(AmbientAttach {
-        parent,
-        depth_base: 0,
-        hello_sent: AtomicBool::new(false),
-      }),
-    }
-  }
-
   #[test]
-  fn negotiate_picks_first_supported_token() {
-    assert_eq!(negotiate("ndjson-crap/1"), Some("ndjson-crap/1"));
+  fn recipe_complete_signal() {
+    let out = capture(|s| {
+      s.emit(&Event::RecipeComplete {
+        tp: 1,
+        exit_code: None,
+        signal: Some("SIGINT"),
+        duration_ms: 312,
+      });
+    });
     assert_eq!(
-      negotiate("crap-pack/1, ndjson-crap/1;families=execution+result"),
-      Some("ndjson-crap/1"),
+      out,
+      "{\"type\":\"recipe_complete\",\"tp\":1,\
+       \"exit_code\":null,\"signal\":\"SIGINT\",\
+       \"duration_ms\":312}\n"
     );
-    assert_eq!(negotiate("crap-pack/1"), None);
-    assert_eq!(negotiate("ndjson-crap/2"), None);
-    assert_eq!(negotiate(""), None);
-  }
-
-  #[test]
-  fn random_tp_base_is_in_shared_channel_range() {
-    for _ in 0..16 {
-      let base = random_tp_base();
-      assert!(base >= 1 << 40, "base {base} below 2^40");
-      assert!(base < 1 << 48, "base {base} at or above 2^48");
-    }
   }
 
   #[test]
@@ -604,43 +454,18 @@ mod tests {
   }
 
   #[test]
-  fn ambient_hello_precedes_first_record() {
+  fn granted_base_offsets_tps() {
     let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
-    {
-      let sink = ambient_sink(BufHandle(Arc::clone(&buf)), Some(7));
-      sink.emit(&Event::RecipeCommand {
-        tp: 1,
-        command: "echo hi",
-        line: 1,
-      });
-    }
-    let bytes = Arc::try_unwrap(buf).unwrap().into_inner().unwrap();
-    let out = String::from_utf8(bytes).unwrap();
-    let mut lines = out.lines();
-    let hello = lines.next().unwrap();
-    assert_eq!(
-      hello,
-      format!(
-        "{{\"type\":\"crap\",\"version\":2,\"ndjson\":1,\
-         \"format\":\"ndjson-crap/1\",\"producer\":\"just-us/{}\",\
-         \"parent\":7}}",
-        env!("CARGO_PKG_VERSION"),
-      ),
-    );
-    assert!(
-      lines
-        .next()
-        .unwrap()
-        .starts_with("{\"type\":\"recipe_command\"")
-    );
-    assert!(lines.next().is_none());
+    let sink = ambient_sink(BufHandle(Arc::clone(&buf)), 1 << 32, Some(7));
+    assert_eq!(sink.next_tp(), (1 << 32) + 1);
+    assert_eq!(sink.next_tp(), (1 << 32) + 2);
   }
 
   #[test]
   fn nested_attachment_suppresses_plan() {
     let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
     {
-      let sink = ambient_sink(BufHandle(Arc::clone(&buf)), Some(7));
+      let sink = ambient_sink(BufHandle(Arc::clone(&buf)), 0, Some(7));
       sink.emit_plan(3);
     }
     let bytes = Arc::try_unwrap(buf).unwrap().into_inner().unwrap();
@@ -648,46 +473,24 @@ mod tests {
   }
 
   #[test]
-  fn root_attachment_emits_hello_then_plan() {
+  fn reoffer_scopes_child_under_node() {
     let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
-    {
-      let sink = ambient_sink(BufHandle(Arc::clone(&buf)), None);
-      sink.emit_plan(3);
-    }
-    let bytes = Arc::try_unwrap(buf).unwrap().into_inner().unwrap();
-    let out = String::from_utf8(bytes).unwrap();
-    let mut lines = out.lines();
-    assert!(lines.next().unwrap().starts_with("{\"type\":\"crap\""));
+    let sink = ambient_sink(BufHandle(buf), 0, None);
+    let offer = sink.reoffer_env(42).unwrap();
     assert_eq!(
-      lines.next().unwrap(),
-      "{\"type\":\"plan\",\"version\":1,\"recipe_count\":3}",
+      offer,
+      vec![
+        ("CRAP".to_owned(), "2".to_owned()),
+        ("CRAP_SINK".to_owned(), "/run/crap/test.sock".to_owned()),
+        ("CRAP_PARENT".to_owned(), "42".to_owned()),
+      ],
     );
   }
 
   #[test]
-  fn explicit_sink_emits_no_hello() {
-    let out = capture(|s| s.emit_plan(2));
-    assert_eq!(
-      out,
-      "{\"type\":\"plan\",\"version\":1,\"recipe_count\":2}\n"
-    );
-  }
-
-  #[test]
-  fn recipe_complete_signal() {
-    let out = capture(|s| {
-      s.emit(&Event::RecipeComplete {
-        tp: 1,
-        exit_code: None,
-        signal: Some("SIGINT"),
-        duration_ms: 312,
-      });
-    });
-    assert_eq!(
-      out,
-      "{\"type\":\"recipe_complete\",\"tp\":1,\
-       \"exit_code\":null,\"signal\":\"SIGINT\",\
-       \"duration_ms\":312}\n"
-    );
+  fn explicit_sink_makes_no_reoffer() {
+    let sink = EventSink::from_writer(Vec::new());
+    assert!(sink.reoffer_env(1).is_none());
+    assert!(EventSink::noop().reoffer_env(1).is_none());
   }
 }

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -471,9 +471,7 @@ impl<'src> Justfile<'src> {
       tp,
       name: recipe.name(),
       namepath: &namepath,
-      // Continue the harness's depth numbering when ambient-attached
-      // (CRAP_DEPTH, crap RFC 0002 §2); depth_base is 0 otherwise.
-      depth: depth + events.depth_base(),
+      depth,
       parent: parent_tp,
       doc: recipe.doc(),
       quiet: recipe.quiet,

--- a/src/justfile.rs
+++ b/src/justfile.rs
@@ -235,8 +235,11 @@ impl<'src> Justfile<'src> {
             &invocation.arguments,
             config,
             events,
-            0,    // depth: top-level invocation
-            None, // parent_tp: top-level has no parent
+            0, // depth: top-level invocation
+            // parent_tp: top-level recipes nest under the harness's
+            // CRAP_PARENT node when ambient-attached (crap RFC 0002
+            // §7); otherwise they have no parent.
+            events.root_parent(),
             false,
             overrides,
             &ran,
@@ -468,7 +471,9 @@ impl<'src> Justfile<'src> {
       tp,
       name: recipe.name(),
       namepath: &namepath,
-      depth,
+      // Continue the harness's depth numbering when ambient-attached
+      // (CRAP_DEPTH, crap RFC 0002 §2); depth_base is 0 otherwise.
+      depth: depth + events.depth_base(),
       parent: parent_tp,
       doc: recipe.doc(),
       quiet: recipe.quiet,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ pub(crate) use {
   clap::{CommandFactory, FromArgMatches, Parser as _, ValueEnum},
   clap_complete::{ArgValueCompleter, CompletionCandidate, PathCompleter, engine::ValueCompleter},
   lexiclean::Lexiclean,
-  libc::EXIT_FAILURE,
+  libc::{EXIT_FAILURE, EXIT_SUCCESS},
   rand::seq::IndexedRandom,
   regex::Regex,
   serde::{
@@ -226,6 +226,10 @@ mod config_error;
 mod const_error;
 mod constants;
 mod count;
+#[cfg(unix)]
+mod crap_attach;
+#[cfg(unix)]
+mod crap_serve;
 mod delimiter;
 mod dependency;
 mod dump_format;

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -460,11 +460,11 @@ impl<'src> Recipe<'src> {
         cmd.env(key, value);
       }
 
-      // crap RFC 0002 §6.1: re-offer the attach protocol to the
-      // child, scoped under this recipe's node — a crap-aware child
-      // emits structured records onto our channel; anything else
-      // produces garbage, captured below as `output` records.
-      if let Some(offer) = context.events.reoffer_env(context.tp, context.depth) {
+      // crap RFC 0002 §5: scope the child into our tree — a
+      // crap-aware child connects to the sink itself and nests under
+      // this recipe's node; anything else produces garbage, captured
+      // below as `output` records.
+      if let Some(offer) = context.events.reoffer_env(context.tp) {
         for (key, value) in &offer {
           cmd.env(key, value);
         }
@@ -652,9 +652,9 @@ impl<'src> Recipe<'src> {
       command.env(key, value);
     }
 
-    // crap RFC 0002 §6.1: re-offer to the script child, same as the
-    // linewise path above.
-    if let Some(offer) = context.events.reoffer_env(context.tp, context.depth) {
+    // crap RFC 0002 §5: scope the script child, same as the linewise
+    // path above.
+    if let Some(offer) = context.events.reoffer_env(context.tp) {
       for (key, value) in &offer {
         command.env(key, value);
       }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -25,23 +25,30 @@ fn capture_with_events(
   cmd.stderr(Stdio::piped());
   match cmd.output() {
     Ok(output) => {
+      // Chunk so each serialized record fits a single atomic
+      // `write(2)` on a possibly-shared channel (crap RFC 0002 §7);
+      // consumers concatenate `data` across records by contract.
       if !output.stdout.is_empty() {
         let data = String::from_utf8_lossy(&output.stdout);
-        events.emit(&Event::Output {
-          tp,
-          stream: OutputStream::Stdout,
-          format: OutputDataFormat::Utf8,
-          data: &data,
-        });
+        for chunk in event::chunk_str(&data, event::OUTPUT_CHUNK_BYTES) {
+          events.emit(&Event::Output {
+            tp,
+            stream: OutputStream::Stdout,
+            format: OutputDataFormat::Utf8,
+            data: chunk,
+          });
+        }
       }
       if !output.stderr.is_empty() {
         let data = String::from_utf8_lossy(&output.stderr);
-        events.emit(&Event::Output {
-          tp,
-          stream: OutputStream::Stderr,
-          format: OutputDataFormat::Utf8,
-          data: &data,
-        });
+        for chunk in event::chunk_str(&data, event::OUTPUT_CHUNK_BYTES) {
+          events.emit(&Event::Output {
+            tp,
+            stream: OutputStream::Stderr,
+            format: OutputDataFormat::Utf8,
+            data: chunk,
+          });
+        }
       }
       (Ok(output.status), None)
     }
@@ -453,6 +460,16 @@ impl<'src> Recipe<'src> {
         cmd.env(key, value);
       }
 
+      // crap RFC 0002 §6.1: re-offer the attach protocol to the
+      // child, scoped under this recipe's node — a crap-aware child
+      // emits structured records onto our channel; anything else
+      // produces garbage, captured below as `output` records.
+      if let Some(offer) = context.events.reoffer_env(context.tp, context.depth) {
+        for (key, value) in &offer {
+          cmd.env(key, value);
+        }
+      }
+
       // RFC 0002 §Suppressing Inherited stdout/stderr: when
       // --events-fd is active, capture child output into `output`
       // events instead of inheriting just's stdio. Output events
@@ -633,6 +650,14 @@ impl<'src> Recipe<'src> {
 
     for (key, value) in env {
       command.env(key, value);
+    }
+
+    // crap RFC 0002 §6.1: re-offer to the script child, same as the
+    // linewise path above.
+    if let Some(offer) = context.events.reoffer_env(context.tp, context.depth) {
+      for (key, value) in &offer {
+        command.env(key, value);
+      }
     }
 
     // run it! (with events-fd capture path, per RFC 0002)

--- a/src/run.rs
+++ b/src/run.rs
@@ -6,6 +6,17 @@ pub fn run(args: impl Iterator<Item = impl Into<OsString> + Clone>) -> Result<()
   #[cfg(windows)]
   nu_ansi_term::enable_ansi_support().ok();
 
+  // A CRAP sink server (crap RFC 0002 §6) is this same binary
+  // re-exec'd with a marker by `crap_attach::birth`. Route into the
+  // serve loop before any argument or justfile processing.
+  #[cfg(unix)]
+  if crap_serve::enabled() {
+    return match crap_serve::serve() {
+      EXIT_SUCCESS => Ok(()),
+      code => Err(code),
+    };
+  }
+
   let arguments = Arguments::try_parse_from(args).map_err(|err| {
     err.print().ok();
     err.exit_code()

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -85,11 +85,14 @@ impl Subcommand {
 
     // Validate --events-fd (if set) before any recipe could run.
     // RFC 0002 §Activation: invalid fd MUST cause a non-zero exit
-    // before recipe execution begins.
+    // before recipe execution begins. With the flag absent, fall
+    // back to ambient attachment via a `CRAP=2` environment offer
+    // (crap RFC 0002) — which, by contrast, degrades silently to a
+    // noop sink on any defect.
     let events = if let Some(fd) = config.events_fd {
       EventSink::from_config(config).map_err(|io_error| Error::EventsFdInvalid { fd, io_error })?
     } else {
-      EventSink::noop()
+      EventSink::from_ambient()
     };
 
     let search = Search::search(config)?;

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -88,11 +88,20 @@ impl Subcommand {
     // before recipe execution begins. With the flag absent, fall
     // back to ambient attachment via a `CRAP=2` environment offer
     // (crap RFC 0002) — which, by contrast, degrades silently to a
-    // noop sink on any defect.
+    // noop sink on any defect. Attachment is gated to the
+    // recipe-running subcommands so silent invocations (`--list`,
+    // `--dump`, …) never connect to or birth a sink server, and it
+    // happens here — before any recipe — to satisfy the RFC's
+    // connect-before-spawn rule.
     let events = if let Some(fd) = config.events_fd {
       EventSink::from_config(config).map_err(|io_error| Error::EventsFdInvalid { fd, io_error })?
-    } else {
+    } else if matches!(
+      self,
+      Choose { .. } | Command { .. } | Evaluate { .. } | Run { .. }
+    ) {
       EventSink::from_ambient()
+    } else {
+      EventSink::noop()
     };
 
     let search = Search::search(config)?;


### PR DESCRIPTION
Implement the CRAP attach protocol (crap RFC 0002) for ambient detection and connection to a crap-aware harness via environment offers. This enables just-us to participate in hierarchical event streams where a parent harness provides a sink server via `CRAP=2` environment variables.

## Summary

This change adds client-side and server-side implementations of crap RFC 0002:

- **Client attachment** (`crap_attach`): Detects `CRAP=2` offers, connects to inherited `CRAP_SINK` servers, or—as a root-capable node—births a sink server by re-exec'ing into an embedded serve loop. Terminal roots elect one shared server per tty via atomic bind; non-terminal roots spawn private tree servers. Every failure mode degrades silently per the RFC.

- **Embedded server** (`crap_serve`): This same binary re-exec'd with an internal marker, receiving a pre-bound listener and splicing complete record lines from all connections to merged output in arrival order. Grants disjoint deterministic id bases (`k·2^32`) per connection. Tree servers exit on lease EOF; terminal servers are refcounted and ignore SIGINT/SIGHUP.

- **Event sink integration**: `EventSink` now supports ambient attachment alongside explicit `--events-fd`. Ambient sinks use granted bases for test-point numbering, enabling single-producer streams to be byte-identical to `--events-fd` streams. Nested nodes suppress plan records and re-export the offer to children.

- **Child scoping** (RFC §5): Recipe children receive `CRAP`/`CRAP_SINK`/`CRAP_PARENT=<recipe tp>` in their environment—crap-aware children connect themselves and nest; others emit garbage captured as chunked `output` records (8 KiB chunks with JSON-escaping headroom).

- **Output chunking**: Large captured output is split at character boundaries to keep serialized record lines under 64 KiB per RFC hygiene guidance.

## Key changes

- **New modules**: `src/crap_attach.rs` (client, root election, server birthing) and `src/crap_serve.rs` (embedded server loop, grant exchange, line splicing).

- **`EventSink` redesign**: Added `ambient` field tracking parent node and sink path; `next_tp` now holds the granted base; new `from_ambient()` constructor; `reoffer_env()` method for child scoping; `root_parent()` accessor; `emit_plan()` suppressed when nested.

- **Recipe execution**: Children receive re-offered CRAP environment via `reoffer_env()`; captured output is chunked via `event::chunk_str()`.

- **Evaluator**: Backtick/`shell()` children have the CRAP offer withdrawn (evaluation is not execution).

- **Subcommand routing**: Ambient attachment happens at startup for recipe-running subcommands; `--list` and friends never touch a sink.

- **Entry point**: `src/run.rs` routes into `crap_serve::serve()` before argument processing when the marker is present.

- **Documentation**: `docs/features/0002-crap-attach.md` records what the prototype implements, omissions, and divergences from the RFC.

## Implementation details

- **Root election**: Terminal roots (stdout is a tty) join-or-elect via tty-keyed socket path (`tty-<maj>.<min>.sock`); bind wins, `EADDRINUSE` loses and connects. Stale sockets reclaimed under sidecar `flock`. Non-terminal roots spawn private tree servers.

- **Server lifecycle**: Tree servers hold a lease pipe (write end kept by spawner for life); exit on lease EOF with 2s drain grace. Terminal servers are refcounted (1s linger after last disconnect, 10s first-client deadline) and ignore SIGINT/SIGHUP.

- **Grant exchange**: Servers answer each accept with exactly one JSON line: `{"type":"crap","version":2,"base":k·2^32,"format":"ndjson-crap/1"}` in accept order.

- **Failure modes**: Missing socket or refused connection →

https://claude.ai/code/session_01J9roWY95WrC2iAoJy2hqmJ